### PR TITLE
feat: Configure project for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,19 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - Unsplash for providing the image API
 - Replit for the development environment
 - Remote Viewing community for inspiration and feedback
+
+## Deploying to Vercel
+
+This project is configured for easy deployment to Vercel.
+
+1.  **Sign up or Log in to Vercel:** Go to [https://vercel.com/](https://vercel.com/).
+2.  **Import Project:**
+    *   Click on "Add New..." and select "Project".
+    *   Import your Git repository.
+3.  **Configure Project (Vercel should autodetect settings):**
+    *   Vercel will automatically detect the `vercel.json` file and configure the build settings.
+    *   The **Root Directory** should be detected as the root of your project. Vercel will use the `vercel.json` to understand that the frontend is in the `client` directory.
+4.  **Deploy:** Click the "Deploy" button.
+5.  **Done!** Your application will be deployed, and you'll get a unique URL.
+
+Vercel will use the `vercel.json` file in the root of the project to determine the build command and output directory for the frontend application located in the `client` folder. It also includes routing rules necessary for single-page applications.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "builds": [
+    {
+      "src": "client/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "client/dist"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/client/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `vercel.json` file to define build and routing settings for deploying the client application to Vercel.

The `vercel.json` configuration specifies:
- The frontend project root as the `client` directory.
- The build command `npm run build` (via `package.json` in `client`).
- The output directory as `client/dist`.
- SPA rewrite rules to serve `client/index.html` for all routes.

Updates `README.md` with instructions on how to deploy the application to Vercel.