### PR TITLE
fix: Resolve Vercel deployment error and correct output path

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,33 +1,34 @@
-import { defineConfig } from "vite";
+import { defineConfig, PluginOption } from "vite";
 import react from "@vitejs/plugin-react";
 import themePlugin from "@replit/vite-plugin-shadcn-theme-json";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
-export default defineConfig({
-  plugins: [
-    react(),
-    runtimeErrorOverlay(),
-    themePlugin(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
-      ? [
-          await import("@replit/vite-plugin-cartographer").then((m) =>
-            m.cartographer(),
-          ),
-        ]
-      : []),
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+export default defineConfig(async () => {
+  let cartographerPlugin: PluginOption[] = [];
+  if (process.env.NODE_ENV !== "production" && process.env.REPL_ID !== undefined) {
+    const m = await import("@replit/vite-plugin-cartographer");
+    cartographerPlugin = [m.cartographer()];
+  }
+
+  return {
+    plugins: [
+      react(),
+      runtimeErrorOverlay(),
+      themePlugin(),
+      ...cartographerPlugin,
+    ],
+    resolve: {
+      alias: {
+        "@": path.resolve(import.meta.dirname, "client", "src"),
+        "@shared": path.resolve(import.meta.dirname, "shared"),
+        "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      },
     },
-  },
-  root: path.resolve(import.meta.dirname, "client"),
-  build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
-    emptyOutDir: true,
-  },
+    root: path.resolve(import.meta.dirname, "client"),
+    build: {
+      outDir: path.resolve(import.meta.dirname, "dist/public"),
+      emptyOutDir: true,
+    },
+  };
 });

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
       "src": "client/package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "client/dist"
+        "distDir": "client/dist/public"
       }
     }
   ],


### PR DESCRIPTION
Refactors `client/vite.config.ts` to avoid top-level await when conditionally loading the `@replit/vite-plugin-cartographer`. This is done by wrapping the dynamic import in an async function, which resolves the "Top-level await is currently not supported with the 'cjs' output format" error during Vercel builds.

Updates `vercel.json` to set the `builds[0].config.distDir` to `"client/dist/public"`. This aligns with the `build.outDir` specified in `client/vite.config.ts`, ensuring Vercel locates the build artifacts in the correct directory.