### PR TITLE
Remove leaked env file and document deployment plan

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-DATABASE_URL=postgresql://postgres:Polo270392!@db.sijdbbauwwsvzphsokzj.supabase.co:5432/postgres
-UNSPLASH_API_KEY=SEvtaDERuOSpwF9Jcns8DqZkruywPMYLwae9qpz7MX8

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to `.env` and fill in the secrets before running locally.
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DATABASE
+UNSPLASH_API_KEY=your-unsplash-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,21 @@
+# Dependencies
 node_modules
+
+# Build artifacts
 dist
-.DS_Store
 server/public
-vite.config.ts.*
 *.tar.gz
+
+# OS-specific files
+.DS_Store
+
+# Tooling caches
+vite.config.ts.*
+
+# Environment secrets
 .env
+.env.local
+.env.*
+*.env
+*.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ See the [SETUP.md](SETUP.md) guide for detailed instructions on:
 - Setting up your development environment
 - Deploying to Vercel with a PostgreSQL database
 
+## 🔐 Security Notice
+
+If you previously pushed a `.env` file, immediately rotate the exposed credentials (e.g., Postgres `DATABASE_URL`, `UNSPLASH_API_KEY`) and delete the leaked secret versions from any dashboards. The repository now includes a `.env.example` template; copy it to `.env` locally and keep the real values outside version control.
+
 ## 📝 License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
@@ -96,8 +100,17 @@ This project is configured for easy deployment to Vercel.
     *   Import your Git repository.
 3.  **Configure Project (Vercel should autodetect settings):**
     *   Vercel will automatically detect the `vercel.json` file and configure the build settings.
-    *   The **Root Directory** should be detected as the root of your project. Vercel will use the `vercel.json` to understand that the frontend is in the `client` directory.
-4.  **Deploy:** Click the "Deploy" button.
-5.  **Done!** Your application will be deployed, and you'll get a unique URL.
+    *   The **Root Directory** should be detected as the root of your project. Vercel will use the `vercel.json` to understand that the frontend is in the `client` directory and that the production bundle lives in `dist/public`.
+4.  **Set Environment Variables:** In the "Environment Variables" tab add the required secrets (for example `DATABASE_URL` for Postgres and `UNSPLASH_API_KEY` if you use the Unsplash integration). These values need to be present for the serverless functions to boot successfully.
+5.  **Deploy:** Click the "Deploy" button.
+6.  **Done!** Your application will be deployed, and you'll get a unique URL.
 
-Vercel will use the `vercel.json` file in the root of the project to determine the build command and output directory for the frontend application located in the `client` folder. It also includes routing rules necessary for single-page applications.
+Vercel will use the `vercel.json` file in the root of the project to determine the build command and output directory for the frontend application located in the `client` folder. It also includes routing rules necessary for single-page applications and assumes the built assets are emitted to `dist/public`.
+
+### Deployment readiness plan
+
+1. **Verify environment isolation:** Confirm that all secrets live only in Vercel project settings (or other secret managers) and that local `.env` files stay untracked.
+2. **Provision production database:** Run migrations against the managed Postgres instance (e.g., via `npm run db:push`) and confirm connectivity from the serverless function.
+3. **Validate build pipeline locally:** Execute `npm run build --prefix client` and `vercel build` to replicate the production build, ensuring `dist/public` is generated with the latest assets.
+4. **Smoke-test serverless handlers:** Use `vercel dev` to run the API locally, then redeploy and confirm logs show successful initialization.
+5. **Set up monitoring & rotations:** Enable Vercel deployment notifications and schedule regular secret rotations in case credentials are exposed again.

--- a/vercel.json
+++ b/vercel.json
@@ -4,14 +4,15 @@
       "src": "client/package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "client/dist/public"
+        "distDir": "dist/public"
       }
     }
   ],
   "routes": [
+    { "handle": "filesystem" },
     {
       "src": "/(.*)",
-      "dest": "/client/index.html"
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- remove the committed `.env` file and provide a safe `.env.example` template for local secrets
- tighten `.gitignore` rules so environment files stay untracked while keeping the template versioned
- document the credential rotation warning and outline a deployment readiness plan in the README

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68f4872b7d448330b80218798deee484