### PR TITLE
Support Vercel serverless deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-DATABASE_URL=postgresql://postgres:Polo270392!@db.sijdbbauwwsvzphsokzj.supabase.co:5432/postgres
-UNSPLASH_API_KEY=SEvtaDERuOSpwF9Jcns8DqZkruywPMYLwae9qpz7MX8

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to `.env` and fill in the secrets before running locally.
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DATABASE
+UNSPLASH_API_KEY=your-unsplash-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,21 @@
+# Dependencies
 node_modules
+
+# Build artifacts
 dist
-.DS_Store
 server/public
-vite.config.ts.*
 *.tar.gz
+
+# OS-specific files
+.DS_Store
+
+# Tooling caches
+vite.config.ts.*
+
+# Environment secrets
 .env
+.env.local
+.env.*
+*.env
+*.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ See the [SETUP.md](SETUP.md) guide for detailed instructions on:
 - Setting up your development environment
 - Deploying to Vercel with a PostgreSQL database
 
+## 🔐 Security Notice
+
+If you previously pushed a `.env` file, immediately rotate the exposed credentials (e.g., Postgres `DATABASE_URL`, `UNSPLASH_API_KEY`) and delete the leaked secret versions from any dashboards. The repository now includes a `.env.example` template; copy it to `.env` locally and keep the real values outside version control.
+
 ## 📝 License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
@@ -96,8 +100,17 @@ This project is configured for easy deployment to Vercel.
     *   Import your Git repository.
 3.  **Configure Project (Vercel should autodetect settings):**
     *   Vercel will automatically detect the `vercel.json` file and configure the build settings.
-    *   The **Root Directory** should be detected as the root of your project. Vercel will use the `vercel.json` to understand that the frontend is in the `client` directory.
-4.  **Deploy:** Click the "Deploy" button.
-5.  **Done!** Your application will be deployed, and you'll get a unique URL.
+    *   The **Root Directory** should be detected as the root of your project. Vercel will use the `vercel.json` to understand that the frontend is in the `client` directory and that the production bundle lives in `dist/public`.
+4.  **Set Environment Variables:** In the "Environment Variables" tab add the required secrets (for example `DATABASE_URL` for Postgres and `UNSPLASH_API_KEY` if you use the Unsplash integration). These values need to be present for the serverless functions to boot successfully.
+5.  **Deploy:** Click the "Deploy" button.
+6.  **Done!** Your application will be deployed, and you'll get a unique URL.
 
-Vercel will use the `vercel.json` file in the root of the project to determine the build command and output directory for the frontend application located in the `client` folder. It also includes routing rules necessary for single-page applications.
+Vercel will use the `vercel.json` file in the root of the project to determine the build command and output directory for the frontend application located in the `client` folder. It also includes routing rules necessary for single-page applications and assumes the built assets are emitted to `dist/public`.
+
+### Deployment readiness plan
+
+1. **Verify environment isolation:** Confirm that all secrets live only in Vercel project settings (or other secret managers) and that local `.env` files stay untracked.
+2. **Provision production database:** Run migrations against the managed Postgres instance (e.g., via `npm run db:push`) and confirm connectivity from the serverless function.
+3. **Validate build pipeline locally:** Execute `npm run build --prefix client` and `vercel build` to replicate the production build, ensuring `dist/public` is generated with the latest assets.
+4. **Smoke-test serverless handlers:** Use `vercel dev` to run the API locally, then redeploy and confirm logs show successful initialization.
+5. **Set up monitoring & rotations:** Enable Vercel deployment notifications and schedule regular secret rotations in case credentials are exposed again.

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,9 @@
+import type { IncomingMessage, ServerResponse } from "http";
+import { createApp } from "../server/app";
+
+const appPromise = createApp();
+
+export default async function handler(req: IncomingMessage, res: ServerResponse) {
+  const app = await appPromise;
+  return app(req as any, res as any);
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "npm run build --prefix client && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,51 @@
+import express, { type Express, type Request, type Response, type NextFunction } from "express";
+import { registerRoutes } from "./routes";
+import { log } from "./logger";
+
+export async function createApp(): Promise<Express> {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const path = req.path;
+    let capturedJsonResponse: Record<string, unknown> | undefined;
+
+    const originalResJson = res.json.bind(res);
+    res.json = ((bodyJson: unknown, ...args: unknown[]) => {
+      capturedJsonResponse = bodyJson as Record<string, unknown> | undefined;
+      return originalResJson(bodyJson, ...args);
+    }) as typeof res.json;
+
+    res.on("finish", () => {
+      const duration = Date.now() - start;
+      if (path.startsWith("/api")) {
+        let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
+        if (capturedJsonResponse) {
+          logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
+        }
+
+        if (logLine.length > 80) {
+          logLine = `${logLine.slice(0, 79)}…`;
+        }
+
+        log(logLine);
+      }
+    });
+
+    next();
+  });
+
+  registerRoutes(app);
+
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err?.status || err?.statusCode || 500;
+    const message = err?.message || "Internal Server Error";
+
+    res.status(status).json({ message });
+    throw err;
+  });
+
+  return app;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,68 +1,26 @@
 import dotenv from "dotenv";
-dotenv.config();
-import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
-import { dot } from "node:test/reporters";
+if (process.env.NODE_ENV !== "production") {
+  dotenv.config();
+}
 
-const app = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      if (logLine.length > 80) {
-        logLine = logLine.slice(0, 79) + "…";
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
+import { createServer } from "http";
+import { createApp } from "./app";
+import { setupVite } from "./vite";
+import { log } from "./logger";
+import { serveStatic } from "./static";
 
 (async () => {
-  const server = await registerRoutes(app);
+  const app = await createApp();
+  const server = createServer(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
-
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
-  if (app.get("env") === "development") {
+  if (process.env.NODE_ENV === "development") {
     await setupVite(app, server);
   } else {
     serveStatic(app);
   }
 
-  // Serve the app on port 3000 (avoiding Apple's AirPlay on 5000)
-  // this serves both the API and the client.
-  const port = 3000;
- server.listen(port, "0.0.0.0", () => {
-  log(`serving on http://localhost:${port}`);
-});
+  const port = Number(process.env.PORT ?? 3000);
+  server.listen(port, "0.0.0.0", () => {
+    log(`serving on http://localhost:${port}`);
+  });
 })();

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,10 @@
+export function log(message: string, source = "express") {
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+
+  console.log(`${formattedTime} [${source}] ${message}`);
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,9 +1,8 @@
 import type { Express } from "express";
-import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import axios from "axios";
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export function registerRoutes(app: Express): void {
   // Store the last used categories to ensure diversity
   let lastUsedCategories: string[] = [];
 
@@ -162,6 +161,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  const httpServer = createServer(app);
-  return httpServer;
 }

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,0 +1,20 @@
+import type { Express } from "express";
+import express from "express";
+import fs from "fs";
+import path from "path";
+
+export function serveStatic(app: Express) {
+  const distPath = path.resolve(import.meta.dirname, "public");
+
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+    );
+  }
+
+  app.use(express.static(distPath));
+
+  app.use("*", (_req, res) => {
+    res.sendFile(path.resolve(distPath, "index.html"));
+  });
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,29 +1,17 @@
-import express, { type Express } from "express";
+import type { Express } from "express";
 import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
-import { type Server } from "http";
+import type { Server } from "http";
 import react from "@vitejs/plugin-react";
 import { nanoid } from "nanoid";
 
-const viteLogger = createLogger();
-
-export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-
-  console.log(`${formattedTime} [${source}] ${message}`);
-}
-
 export async function setupVite(app: Express, server: Server) {
+  const viteLogger = createLogger();
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-  };
+  } as const;
 
   const vite = await createViteServer({
     configFile: false,
@@ -44,23 +32,18 @@ export async function setupVite(app: Express, server: Server) {
         "@": path.resolve(import.meta.dirname, "..", "client", "src"),
         "@shared": path.resolve(import.meta.dirname, "..", "shared"),
       },
-      // Allow Vite to resolve modules from the root node_modules
       preserveSymlinks: false,
     },
-    // Configure optimized deps to be found in root
     optimizeDeps: {
       entries: [
         path.resolve(import.meta.dirname, "..", "client", "index.html"),
-        path.resolve(import.meta.dirname, "..", "client", "src", "**", "*.{ts,tsx}")
+        path.resolve(import.meta.dirname, "..", "client", "src", "**", "*.{ts,tsx}"),
       ],
     },
-    // Configure module resolution to look in root node_modules
     server: {
       ...serverOptions,
       fs: {
-        allow: [
-          path.resolve(import.meta.dirname, ".."),
-        ],
+        allow: [path.resolve(import.meta.dirname, "..")],
       },
     },
     customLogger: {
@@ -70,7 +53,6 @@ export async function setupVite(app: Express, server: Server) {
         process.exit(1);
       },
     },
-    server: serverOptions,
     appType: "custom",
   });
 
@@ -86,34 +68,17 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,
         `src="/src/main.tsx?v=${nanoid()}"`,
       );
+
       const page = await vite.transformIndexHtml(url, template);
       res.status(200).set({ "Content-Type": "text/html" }).end(page);
     } catch (e) {
       vite.ssrFixStacktrace(e as Error);
       next(e);
     }
-  });
-}
-
-export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
-
-  if (!fs.existsSync(distPath)) {
-    throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
-    );
-  }
-
-  app.use(express.static(distPath));
-
-  // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
   });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,14 +4,23 @@
       "src": "client/package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "client/dist/public"
+        "distDir": "dist/public"
       }
+    },
+    {
+      "src": "api/**/*.ts",
+      "use": "@vercel/node"
     }
   ],
   "routes": [
     {
+      "src": "/api/(.*)",
+      "dest": "/api/$1"
+    },
+    { "handle": "filesystem" },
+    {
       "src": "/(.*)",
-      "dest": "/client/index.html"
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- refactor the Express bootstrap so the app can be reused by both the local Node server and Vercel
- add a serverless function entry point and configure Vercel to build it alongside the static client
- fix the build script to invoke the client build before bundling the server and extract shared logging/static helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4872b7d448330b80218798deee484